### PR TITLE
Remove silent and auto install apt-get flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The GUI version requires GTK+ >= 3.6.16, which installation depends on your OS:
 
 **Ubuntu:**
 
-	sudo apt-get install -qq -y gtk+3.0 libgtk-3-dev
+	sudo apt-get install gtk+3.0 libgtk-3-dev
 
 **Mac:**
 


### PR DESCRIPTION
I think it would be better for people to know what dependences are being installed with gtk+3.0 and libgtk-3-dev. Hiding this from the user with the intention to keep things simple might not be the best idea.

Thoughts?
